### PR TITLE
Support team ID or name in config.json (issue-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ appropriate config items. This includes the `token`, `owner`, and `team`
     AuthorizedKeysCommandUser deploy
     # or root if you're feelin' gutsy
 
+## Team ID
+
+Optionally, change config.json's `team` to `team_id` and specify the ID of your team. By using the team ID rather than the team name, sshauth will continue to work as before in the event you rename your team. If you specify both `team` and `team_id`, only the `team_id` will be honored. Example:
+
+    {
+      "token" : "your oauth token here",
+      "owner" : "user or owner name here",
+      "team_id": 1234567
+    }
+
+To find a team ID, create [a personal OAuth token](https://github.com/settings/tokens) then use it to make an API request:
+
+    curl -H "Authorization: token <YOUR OAUTH TOKEN HERE>" https://api.github.com/orgs/<YOUR ORG HERE>/teams
+
+Make sure to replace `<YOUR OAUTH TOKEN HERE>` with a personal oauth token, and `<YOUR ORG HERE>` with the organization that owns the team. For more information on the github API, see the [official documentation](https://developer.github.com/v3/orgs/teams/#list-teams).
+
 ## Notes
 
 - Keys aren't cached, so every SSH authentication request makes several API

--- a/github.go
+++ b/github.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
-	"strings"
 )
 
 //- naive oauth setup
@@ -29,6 +30,11 @@ type GithubClient struct {
 func (c *GithubClient) GetKeys(user github.User) ([]github.Key, error) {
 	keys, _, err := c.client.Users.ListKeys(*user.Login, nil)
 	return keys, err
+}
+
+func (c *GithubClient) GetTeamMembersByID(teamID int) ([]github.User, error) {
+	users, _, err := c.client.Organizations.ListTeamMembers(teamID, nil)
+	return users, err
 }
 
 func (c *GithubClient) GetTeamMembers(name string) ([]github.User, error) {


### PR DESCRIPTION
See https://github.com/trevoro/sshauth/issues/3

This feature allows a user to provide either the `team` name (just as before) or `team_id` (brand new) in the config.json file. When using only the team name, sshauth will break if the name of the team changes. By using the team ID, sshauth is more resilient to changes.

Another bonus to the resiliency is that in organizations with multiple teams, one fewer API call is made to retrieve the team members per ssh connection; so using a team ID could enable more ssh connections before hitting the Github API rate limits.

This feature is fully backwards compatible. Here's an example of the new config.json style:

``` json
{
  "owner": "coreos",
  "token": "super-duper-secret-oauth-token-here",
  "team_id": 123456
}
```

**Note that `team_id` must be an `int` not a string.**

For a given organization `foo`, to retrieve the ID of a team from the Github API that you are a part of:

``` bash
$ curl -u brycefisher:mypassword https://api.github.com/orgs/foo/teams
[
  {
    "name": "Team Awesome Sauce",
    "id": 2021031,
    "slug": "team-awesome-sauce",
    "description": "This team rocks!",
    "permission": "pull",
    "privacy": "closed",
    "url": "https://api.github.com/teams/2021031",
    "members_url": "https://api.github.com/teams/2021031/members{/member}",
    "repositories_url": "https://api.github.com/teams/2021031/repos"
  }
]
```

I'd also tried to make my changes in a purely additive way to avoid breakage for users of this tool. Specifically, I added a new method `Github.GetTeamMembersByID()` rather than change the behavior or method signature of `GithubClient.GetTeamMembers()` since the latter is a public method and could in theory be used by other packages.
